### PR TITLE
fix: 添加 Python 开发包依赖以支持 C 扩展编译

### DIFF
--- a/Script/MaiBot/MaiBot-install.sh
+++ b/Script/MaiBot/MaiBot-install.sh
@@ -275,6 +275,18 @@ install_system_dependencies() {   #定义函数
             *) packages+=("python3-pip") ;;                  #默认
         esac                                                 #结束条件判断
     fi
+    # 检查 Python 开发包
+    if ! command_exists python3-config; then
+        case $PKG_MANAGER in
+            apt) packages+=("python3-dev") ;;
+            pacman) packages+=("python") ;;
+            dnf|yum) packages+=("python3-devel") ;;
+            zypper) packages+=("python3-devel") ;;
+            apk) packages+=("python3-dev") ;;
+            brew) ;; 
+            *) packages+=("python3-dev") ;;
+        esac
+    fi
     # 检查 gcc/g++ 是否存在，如果都不存在则安装
     if ! command_exists gcc || ! command_exists g++; then
      case $PKG_MANAGER in


### PR DESCRIPTION
在 ARM64 等架构上安装时，quick-algo 等包需要从源码编译 C++ 扩展，
但脚本缺少 Python 开发头文件依赖，导致编译失败。

错误信息：
  fatal error: Python.h: No such file or directory

此修改为不同包管理器添加对应的 Python 开发包：
- apt: python3-dev
- dnf/yum: python3-devel
- apk: python3-dev
- pacman/brew: 已包含在基础 python 包中

测试环境：Ubuntu 22.04 ARM64, Python 3.10.12